### PR TITLE
Add aliases

### DIFF
--- a/src/components/hero/Hero.tsx
+++ b/src/components/hero/Hero.tsx
@@ -1,8 +1,8 @@
+import SkillsGroup from "@components/hero/SkillsGroup";
+import Column from "@components/layout/Column";
+import Container from "@components/layout/Container";
+import Row from "@components/layout/Row";
 import { FunctionComponent } from "react";
-import Column from "../layout/Column";
-import Container from "../layout/Container";
-import Row from "../layout/Row";
-import SkillsGroup from "./SkillsGroup";
 
 const Hero: FunctionComponent = () => {
   const softSkills = ["hi"];

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,22 +2,29 @@
   "compilerOptions": {
     "target": "ES5" /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */,
     "module": "ESNext" /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */,
-    "moduleResolution": "node" /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */ /* Type declaration files to be included in compilation. */,
-    "lib": [
-      "DOM",
-      "ESNext"
-    ] /* Specify library files to be included in the compilation. */,
-    "jsx": "react-jsx" /* Specify JSX code generation: 'preserve', 'react-native', 'react' or 'react-jsx'. */,
-    "noEmit": true /* Do not emit outputs. */,
-    "isolatedModules": true /* Transpile each file as a separate module (similar to 'ts.transpileModule'). */,
-    "esModuleInterop": true /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */,
-    "strict": true /* Enable all strict type-checking options. */,
-    "skipLibCheck": true /* Skip type checking of declaration files. */,
-    "forceConsistentCasingInFileNames": true /* Disallow inconsistently-cased references to the same file. */,
-    "resolveJsonModule": true,
+    "jsx": "preserve" /* Specify JSX code generation: 'preserve', 'react-native', 'react' or 'react-jsx'. */,
     "allowJs": true /* Allow javascript files to be compiled. Useful when migrating JS to TS */,
-    "checkJs": true /* Report errors in .js files. Works in tandem with allowJs. */
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+
+    "moduleResolution": "node" /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */ /* Type declaration files to be included in compilation. */,
+    "lib": ["dom", "es2015", "es2016", "esnext"],
+    "strict": false /* Enable all strict type-checking options. */,
+    "forceConsistentCasingInFileNames": true /* Disallow inconsistently-cased references to the same file. */,
+    "esModuleInterop": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "sourceMap": true,
+    "inlineSources": true,
+    "sourceRoot": "/",
+    "baseUrl": "./",
+    "paths": {
+      "@public/*": ["public/*"],
+      "@components/*": ["src/components/*"]
+    }
   },
-  "include": ["src/**/*"],
-  "exclude": ["node_modules", "build"] // *** The files to not type check ***
+  "include": ["typings", "src"],
+  "exclude": ["node_modules", "dist"] // *** The files to not type check ***
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -23,6 +23,10 @@ module.exports = {
   },
   resolve: {
     extensions: [".tsx", ".ts", ".js", ".jsx"],
+    alias: {
+      "@public": path.join(__dirname, "public"),
+      "@components": path.join(__dirname, "src", "components"),
+    },
   },
   plugins: [
     new HtmlWebpackPlugin({


### PR DESCRIPTION
This PR creates aliases for often used path.

### ===Instruction===
To add new alias:
1. **webpack.config.js** - add a new line in `alias` property:
```
 resolve: {
    ...
    alias: {
      "@public": path.join(__dirname, "public"),
      "@components": path.join(__dirname, "src", "components"),
      [past a new rule here]
    },
 },
```
2. **tsconfig.json** - add a new line in `paths` property:
```
"paths": {
      "@public/*": ["public/*"],
      "@components/*": ["src/components/*"]
      [past a new rule here]
 }
```
3. Use in component file in import path like this `import Column from "@components/layout/Column";`